### PR TITLE
Implement Reduce transformer

### DIFF
--- a/src/main/java/loghub/transformers/Reduce.java
+++ b/src/main/java/loghub/transformers/Reduce.java
@@ -1,0 +1,27 @@
+package loghub.transformers;
+
+import java.util.Map;
+import java.util.LinkedList;
+import java.util.List;
+
+import loghub.Event;
+import loghub.Transformer;
+import loghub.configuration.Beans;
+
+@Beans({"script"})
+public class Reduce extends Transformer  {
+
+    protected LinkedList<Transformer> transformers;
+    public Reduce(Map<String, Event> eventQueue, List<Transformer> t) {
+        super(eventQueue);
+        setName("TransformerReduce");
+        transformers = LinkedList<Transformer>(t);
+    }
+
+    @Override
+    public void transform(Event event) {
+        for(Transformer transformer : transformers) {
+            transformer.transform(event);
+        }
+    }
+}


### PR DESCRIPTION
To avoid context switching, this transformer can reuse other
transformers

Like:

```
              |
              v
   /---------------------\
   | Add Field (thread1) |
   \---------------------/
              |
              v
   /------------------------\
   | Change Field (thread2) |
   \------------------------/
              |
              v
  /-----------------------\
  | Remove Field (thread3)|
  \-----------------------/
              |
              v
```

to:

```
         |                      /---------------------\
         |                 /----| Add Field (thread1) |
         |                 |    \---------------------/
         v                 |
   /------------------\    |    /------------------------\
   | Reduce (thread1) |----+----| Change field (thread1) |
   \------------------/    |    \------------------------/
         |                 |
         |                 |    /------------------------\
         |                 \----| Remove Field (thread1) |
         |                      \------------------------/
         v
```
